### PR TITLE
Added **kwargs to call methond as keyword arguments

### DIFF
--- a/lib/redmine_gtt_export/members_to_csv.rb
+++ b/lib/redmine_gtt_export/members_to_csv.rb
@@ -4,8 +4,8 @@ module RedmineGttExport
   class MembersToCsv
     include Redmine::I18n
 
-    def self.call(*_)
-      new(*_).call
+    def self.call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
 
     def initialize(project)


### PR DESCRIPTION
Fixes possible error on Redmine5.0 + Ruby3.1 environment.

Changes proposed in this pull request:
- Added `**kwargs` to call methond as keyword arguments

@gtt-project/maintainer
